### PR TITLE
Add profile chat

### DIFF
--- a/packages/homes/src/containers/Agent/AccountDetails/AgentBookingPage.jsx
+++ b/packages/homes/src/containers/Agent/AccountDetails/AgentBookingPage.jsx
@@ -1,15 +1,17 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { AuthContext } from 'context/AuthProvider';
 import useDataApi from 'library/hooks/useDataApi';
 import Container from 'components/UI/Container/Container';
 import Heading from 'components/UI/Heading/Heading';
 import Loader from 'components/Loader/Loader';
 import Text from 'components/UI/Text/Text';
+import ChatModal from './ChatModal';
 import { useNavigate } from 'react-router-dom';
 
 const AgentBookingPage = () => {
   const { loggedIn, user: userInfo } = useContext(AuthContext);
   const navigate = useNavigate();
+  const [activeBookingId, setActiveBookingId] = useState(null);
 
   useEffect(() => {
     if (!loggedIn) {
@@ -37,9 +39,8 @@ const AgentBookingPage = () => {
     // TODO: Show modal or redirect with form
   };
 
-  const handleMessageHost = (property) => {
-    console.log('Message host for property:', property);
-    // TODO: Open contact modal or messaging system
+  const handleMessageHost = (bookingId) => {
+    setActiveBookingId(bookingId);
   };
 
   if (!loggedIn) return null; // Or <Loader />
@@ -101,7 +102,7 @@ const AgentBookingPage = () => {
                 </button>
                 <button
                   style={{ padding: '6px 12px' }}
-                  onClick={() => handleMessageHost(property)}
+                  onClick={() => handleMessageHost(id)}
                 >
                   💬 Message Host
                 </button>
@@ -112,6 +113,11 @@ const AgentBookingPage = () => {
       ) : (
         <Text content="You have no bookings yet." />
       )}
+      <ChatModal
+        bookingId={activeBookingId}
+        open={!!activeBookingId}
+        onClose={() => setActiveBookingId(null)}
+      />
     </Container>
   );
 };

--- a/packages/homes/src/containers/Agent/AccountDetails/AgentChatPage.jsx
+++ b/packages/homes/src/containers/Agent/AccountDetails/AgentChatPage.jsx
@@ -1,0 +1,53 @@
+import React, { useContext, useState } from 'react';
+import Container from 'components/UI/Container/Container';
+import Heading from 'components/UI/Heading/Heading';
+import Loader from 'components/Loader/Loader';
+import { AuthContext } from 'context/AuthProvider';
+import useDataApi from 'library/hooks/useDataApi';
+import ChatModal from './ChatModal';
+
+const AgentChatPage = () => {
+  const { user } = useContext(AuthContext);
+  const { data: bookingsData, loading } = useDataApi(
+    `${import.meta.env.VITE_APP_API_URL}proeprty-bookings?filters[users_permissions_user][id][$eq]=${user?.id}&populate=property`,
+    import.meta.env.VITE_APP_API_TOKEN,
+    10,
+    'proeprty-bookings',
+    [],
+  );
+  const [activeBookingId, setActiveBookingId] = useState(null);
+
+  if (loading) return <Loader />;
+
+  return (
+    <Container>
+      <Heading as="h3" content="Chat with Hosts" />
+      {bookingsData?.length ? (
+        bookingsData.map((booking) => (
+          <div
+            key={booking.id}
+            style={{
+              padding: '16px',
+              border: '1px solid #eee',
+              marginBottom: '10px',
+            }}
+          >
+            <p>{booking.property?.Title || 'Untitled Property'}</p>
+            <button onClick={() => setActiveBookingId(booking.id)}>
+              Open Chat
+            </button>
+          </div>
+        ))
+      ) : (
+        <p>No bookings found</p>
+      )}
+      <ChatModal
+        bookingId={activeBookingId}
+        open={!!activeBookingId}
+        onClose={() => setActiveBookingId(null)}
+      />
+    </Container>
+  );
+};
+
+export default AgentChatPage;

--- a/packages/homes/src/containers/Agent/AccountDetails/AgentDetailsViewPage.jsx
+++ b/packages/homes/src/containers/Agent/AccountDetails/AgentDetailsViewPage.jsx
@@ -24,6 +24,7 @@ import {
   AGENT_PROFILE_BOOKING,
   AGENT_PROFILE_FAVORITE,
   AGENT_PROFILE_LISTING,
+  AGENT_PROFILE_CHAT,
 } from 'settings/constant';
 import AgentDetailsPage, {
   BannerSection,
@@ -68,6 +69,14 @@ const ProfileNavigation = (props) => {
         </NavLink>
       ),
       key: 'favorite',
+    },
+    {
+      label: (
+        <NavLink to={`${AGENT_PROFILE_PAGE}/${AGENT_PROFILE_CHAT}`}>
+          Chat
+        </NavLink>
+      ),
+      key: 'chat',
     },
   ];
 

--- a/packages/homes/src/containers/Agent/AccountDetails/ChatModal.jsx
+++ b/packages/homes/src/containers/Agent/AccountDetails/ChatModal.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Input, Button, List } from 'antd';
+import PropTypes from 'prop-types';
+import { useChat } from 'context/ChatProvider';
+
+const ChatModal = ({ bookingId, open, onClose }) => {
+  const { messages, connect, disconnect, sendMessage } = useChat();
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      connect(bookingId);
+    }
+    return () => disconnect();
+  }, [open, bookingId]);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    sendMessage({ bookingId, message: input });
+    setInput('');
+  };
+
+  return (
+    <Modal open={open} onCancel={onClose} footer={null} title="Chat">
+      <List
+        dataSource={messages}
+        renderItem={(item, index) => (
+          <List.Item key={index}>{item.message}</List.Item>
+        )}
+        style={{ marginBottom: '1rem' }}
+      />
+      <Input.TextArea
+        rows={3}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <Button type="primary" onClick={handleSend} style={{ marginTop: '8px' }}>
+        Send
+      </Button>
+    </Modal>
+  );
+};
+
+ChatModal.propTypes = {
+  bookingId: PropTypes.number,
+  open: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default ChatModal;

--- a/packages/homes/src/context/ChatProvider.jsx
+++ b/packages/homes/src/context/ChatProvider.jsx
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useRef, useState } from 'react';
+
+export const ChatContext = createContext();
+
+const ChatProvider = ({ children }) => {
+  const socketRef = useRef(null);
+  const [messages, setMessages] = useState([]);
+
+  const connect = (bookingId) => {
+    if (!bookingId) return;
+    const wsUrl = `${import.meta.env.VITE_APP_CHAT_WS}?booking=${bookingId}`;
+    socketRef.current = new WebSocket(wsUrl);
+    socketRef.current.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setMessages((prev) => [...prev, data]);
+      } catch {
+        /* ignore invalid data */
+      }
+    };
+    socketRef.current.onclose = () => {
+      socketRef.current = null;
+    };
+  };
+
+  const disconnect = () => {
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+    }
+    setMessages([]);
+  };
+
+  const sendMessage = (message) => {
+    if (socketRef.current && socketRef.current.readyState === 1) {
+      socketRef.current.send(JSON.stringify(message));
+      setMessages((prev) => [...prev, { ...message, pending: true }]);
+    }
+  };
+
+  return (
+    <ChatContext.Provider
+      value={{ messages, connect, disconnect, sendMessage }}
+    >
+      {children}
+    </ChatContext.Provider>
+  );
+};
+
+export const useChat = () => useContext(ChatContext);
+
+export default ChatProvider;

--- a/packages/homes/src/index.jsx
+++ b/packages/homes/src/index.jsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from 'styled-components';
 import theme from 'themes/default.theme';
 import GlobalStyles from 'themes/global.style';
 import AuthProvider from 'context/AuthProvider';
+import ChatProvider from 'context/ChatProvider';
 import AppRoutes from './router';
 import { ConfigProvider } from 'antd';
 import 'antd/dist/reset.css';
@@ -16,7 +17,9 @@ const App = () => (
         <GlobalStyles />
         <BrowserRouter>
           <AuthProvider>
-            <AppRoutes />
+            <ChatProvider>
+              <AppRoutes />
+            </ChatProvider>
           </AuthProvider>
         </BrowserRouter>
       </React.Fragment>

--- a/packages/homes/src/router.jsx
+++ b/packages/homes/src/router.jsx
@@ -12,6 +12,7 @@ import {
   AGENT_PROFILE_BOOKING,
   AGENT_PROFILE_FAVORITE,
   AGENT_PROFILE_LISTING,
+  AGENT_PROFILE_CHAT,
   PRIVACY_PAGE,
   LOGIN_PAGE,
   REGISTRATION_PAGE,
@@ -75,6 +76,9 @@ const AgentFavItemLists = React.lazy(
 );
 const AgentBookingPage = React.lazy(
   () => import('containers/Agent/AccountDetails/AgentBookingPage'),
+);
+const AgentChatPage = React.lazy(
+  () => import('containers/Agent/AccountDetails/AgentChatPage'),
 );
 
 const PaymentPage = React.lazy(() => import('containers/Payment/Payment'));
@@ -246,6 +250,15 @@ export default function AppRoutes() {
             element={
               <React.Suspense fallback={<Loader />}>
                 <AgentFavItemLists />
+              </React.Suspense>
+            }
+          />
+
+          <Route
+            path={AGENT_PROFILE_CHAT}
+            element={
+              <React.Suspense fallback={<Loader />}>
+                <AgentChatPage />
               </React.Suspense>
             }
           />

--- a/packages/homes/src/settings/constant.js
+++ b/packages/homes/src/settings/constant.js
@@ -15,6 +15,7 @@ export const AGENT_IMAGE_EDIT_PAGE = 'change-image';
 export const AGENT_PASSWORD_CHANGE_PAGE = 'change-password';
 export const AGENT_PROFILE_DELETE = '/delete';
 export const AGENT_PROFILE_LISTING = 'listing';
+export const AGENT_PROFILE_CHAT = 'chat';
 // Other Pages
 export const PRICING_PLAN_PAGE = '/pricing-plan';
 export const PRIVACY_PAGE = '/privacy';


### PR DESCRIPTION
## Summary
- add ChatProvider context
- create ChatModal and AgentChatPage components
- enable chat navigation in profile
- add chat route and new constant
- integrate chat modal with bookings

## Testing
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_6873a7993ffc832a99ffb95256a1f2ef