### PR TITLE
fix: add atlasora-shared dependency for npm registry resolution

### DIFF
--- a/packages/homes/package.json
+++ b/packages/homes/package.json
@@ -42,7 +42,8 @@
     "styled-components": "^6.1.13",
     "styled-system": "^5.1.5",
     "viem": "^2.32.1",
-    "wagmi": "^2.16.0"
+    "wagmi": "^2.16.0",
+    "atlasora-shared": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",


### PR DESCRIPTION
## Summary

- Adds `atlasora-shared` as a dependency in `packages/homes`
- Fixes build failure where internal packages don't resolve from npm registry

## Problem

The monorepo build fails with:
```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for atlasora-shared
```

## Solution

`atlasora-shared` v1.0.0 is now published to npm. Adding it as a dependency allows `pnpm install` to resolve it.

Related: #31

Package: https://www.npmjs.com/package/atlasora-shared